### PR TITLE
Word Count Checker for Pre-Merge

### DIFF
--- a/.github/workflows/commit-checker.yml
+++ b/.github/workflows/commit-checker.yml
@@ -1,0 +1,23 @@
+name: commit-message-check
+on:
+  pull_request_target:
+    branches: [ master ]
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  check-commit-message:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Check commit message length
+        run: |
+          commit_message=$(git log -1 --pretty=%B)
+          word_count=$(echo $commit_message | wc -w)
+          if [ $word_count -le 5 ]; then
+            echo "Commit message must be more than 5 words."
+            exit 1
+          fi


### PR DESCRIPTION
- It will validate word count in commit messages from each PR.
- Each commit message should have minimum 5 words to raise PR.