### PR TITLE
Fix workflow: use sudo bash -c for sourcing build script

### DIFF
--- a/.github/workflows/process_image.yml
+++ b/.github/workflows/process_image.yml
@@ -123,7 +123,7 @@ jobs:
               
 
               # Copy the arg build files to the mounted image
-              source "/workspace/${FILES_TO_COPY}"
+              sudo bash -c "source /workspace/${FILES_TO_COPY}"
               echo "Build files copied successfully"
               sync
               # Unmount the image


### PR DESCRIPTION
Replace `source "/workspace/${FILES_TO_COPY}"` with `sudo bash -c "source /workspace/${FILES_TO_COPY}"` to resolve permission denied errors when copying binaries inside Docker.