### PR TITLE
ci: Remove the SoC prefix and rename to rb3gen2-core-kit

### DIFF
--- a/.github/workflows/process_image.yml
+++ b/.github/workflows/process_image.yml
@@ -35,9 +35,9 @@ on:
         description: Optional base reference to use for building
         default: ${{ github.ref_name }}
 
-# Using qcs6490 flat_build
+# Using rb3gen2 flat_build
 env:
-  IMAGE_NAME: core-image-base-qcs6490-rb3gen2-core-kit.rootfs.qcomflash
+  IMAGE_NAME: core-image-base-rb3gen2-core-kit.rootfs.qcomflash
 
 jobs:
   process_image:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: "List jobs"
         id: listjobs
         run: |
-          target_file="ci/lava/qcs6490-rb3gen2-core-kit/boot.yaml"
+          target_file="ci/lava/rb3gen2-core-kit/boot.yaml"
           if [ ! -f "$target_file" ]; then
             echo "Target file $target_file does not exist."
             echo "target_file=" >> "$GITHUB_OUTPUT"
@@ -54,7 +54,7 @@ jobs:
           FIND_PATH="${TARGET#*/}"
           DEVICE_TYPE_PATH="${FIND_PATH%/*}"
           DEVICE_TYPE="${DEVICE_TYPE_PATH#*/}"
-          BUILD_FILE_NAME="core-image-base-qcs6490-rb3gen2-core-kit.rootfs.qcomflash.tar.gz"
+          BUILD_FILE_NAME="core-image-base-rb3gen2-core-kit.rootfs.qcomflash.tar.gz"
           BUILD_DOWNLOAD_URL="${{ steps.get_build_url.outputs.build_url }}"
           sed -i "s|{{DEVICE_TYPE}}|${DEVICE_TYPE}|g" "${target_file}"
           sed -i "s|{{GITHUB_SHA}}|${GITHUB_SHA}|g" "${target_file}"


### PR DESCRIPTION
Update boot.yaml by removing qcs6490 from the path and image name to
match the changes referenced in [1].

[1] https://github.com/AudioReach/meta-audioreach/pull/49