### PR TITLE
Replace qcs6490 SDK with rb3gen2 in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,9 +62,9 @@ on:
         description: Optional base reference to use for building
         default: ${{ github.ref_name }}
 
-# Use qcs6490 sdk for compiling, as sdk is similar for all the targets
+# Use rb3gen2 sdk for compiling, as sdk is similar for all the targets
 env:
-  SDK_NAME: sdk-qcs6490.sh
+  SDK_NAME: sdk-rb3gen2.sh
 
 
 jobs:


### PR DESCRIPTION
Update build.yaml to replace qcs6490 SDK with rb3gen2 SDK to match
the changes referenced in [1].

[1] https://github.com/AudioReach/meta-audioreach/pull/49