### PR TITLE
Update qcom-preflight-checks to enforce 72-char commit limits

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -26,15 +26,15 @@ on:
         default: true
       commit-msg-check-extra-options:
         type: string
-        default: ''
-        description: 'Extra options as YAML/JSON object string, e.g., {"body-char-limit": 60, "sub-char-limit": 50, "check-blank-line": true}'
+        default: '{"body-char-limit": 72, "sub-char-limit": 72}'
+        description: 'Extra options as YAML/JSON object string, e.g., {"body-char-limit": 72, "sub-char-limit": 72, "check-blank-line": true}'
 permissions:
   contents: read
   security-events: write
 
 jobs:
   qcom-preflight-checks:
-    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2.0.0
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2
     with:
       # ✅ Preflight Checkers
       enable-semgrep-scan: ${{ inputs.enable-semgrep-scan }}


### PR DESCRIPTION
Set the default commit-msg-check-extra-options to use 72-character limits for both the commit title and body in the preflight-checks workflow, and update the referenced workflow version accordingly.