### PR TITLE
Use rb3gen2 core kit SDK for workflow builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ on:
 
 # Use rb3gen2 sdk for compiling, as sdk is similar for all the targets
 env:
-  SDK_NAME: sdk-rb3gen2.sh
+  SDK_NAME: sdk-rb3gen2-core-kit.sh
 
 
 jobs:


### PR DESCRIPTION
Update the build workflow to use the rb3gen2 core kit SDK instead of the previous rb3gen2 SDK script. Align the workflow with the correct toolchain required for current targets.