### PR TITLE
Consolidate LAVA test results into a single summary

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -1,0 +1,237 @@
+name: 'LAVA Test Submit'
+description: 'Generate and submit LAVA test jobs using lava-test-plans'
+
+inputs:
+  # Build matrix item
+  image_name:
+    description: 'Image name for the build'
+    required: true
+  machine_name:
+    description: 'Machine name for the build'
+    required: true
+  
+  # Build URL
+  build_url:
+    description: 'Presigned URL for the build artifact'
+    required: true
+  
+  # LAVA configuration
+  distro_name:
+    description: 'Distribution name for lava-test-plans'
+    required: false
+    default: 'qcom-distro'
+  kernel:
+    description: 'Extra path suffix for kernel (e.g., -6.18)'
+    required: false
+    default: ''
+  testplan:
+    description: 'Test plan name to use in job generation'
+    required: false
+    default: 'pre-merge'
+  prefix:
+    description: 'Prefix for the compressed artifact with generated jobs'
+    required: false
+    default: 'testjobs'
+  
+  # LAVA server credentials
+  lava_token:
+    description: 'LAVA authentication token'
+    required: true
+  lava_url:
+    description: 'LAVA server URL'
+    required: false
+    default: 'lava.infra.foundries.io'
+  
+  # Job submission options
+  wait_for_job:
+    description: 'Wait for LAVA job to complete'
+    required: false
+    default: 'true'
+  fail_action_on_failure:
+    description: 'Fail action if LAVA job fails'
+    required: false
+    default: 'false'
+  
+  # GitHub context
+  run_id:
+    description: 'GitHub run ID'
+    required: true
+  run_attempt:
+    description: 'GitHub run attempt'
+    required: true
+
+outputs:
+  jobs_path:
+    description: 'Path to generated LAVA job files'
+    value: ${{ steps.generate-jobs.outputs.jobs_path }}
+  first_job:
+    description: 'Path to the first generated job file'
+    value: ${{ steps.generate-jobs.outputs.first_job }}
+  artifact_name:
+    description: 'Name of the uploaded artifact'
+    value: ${{ steps.generate-jobs.outputs.artifact_name }}
+  lava_job_id:
+    description: 'LAVA job ID (if submitted)'
+    value: ${{ steps.submit-job.outputs.job_id }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout lava-test-plans
+      uses: actions/checkout@v5
+      with:
+        repository: qualcomm-linux-stg/lava-test-plans
+        path: lava-test-plans
+        ref: master
+
+    - name: Setup Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+
+    - name: Generate LAVA test jobs
+      id: generate-jobs
+      shell: bash
+      run: |
+        set -euo pipefail
+        cd lava-test-plans && pip install .
+        pip install requests urllib3
+        lava-test-plans --version
+        cd "${GITHUB_WORKSPACE}"
+
+        OUT_PATH="${GITHUB_WORKSPACE}/out"
+        VARS_OUT_PATH="${OUT_PATH}/vars"
+        JOBS_OUT_PATH="${OUT_PATH}/jobs"
+        echo "jobs_path=${JOBS_OUT_PATH}" >> $GITHUB_OUTPUT
+        mkdir -p "${VARS_OUT_PATH}" "${JOBS_OUT_PATH}"
+
+        # === Plan roots as in the installed package ===
+        PROJECT="meta-qcom"
+        DISTRO_NAME="${{ inputs.distro_name }}"
+
+        # Map testplan input to a plan directory
+        TESTPLAN_INPUT="${{ inputs.testplan }}"
+        case "$TESTPLAN_INPUT" in
+          boot)  TESTPLAN_DIR="boot" ;;
+          pre-merge|pre-merge-basic|pre-merge-bt) TESTPLAN_DIR="pre-merge" ;;
+          *)     TESTPLAN_DIR="$TESTPLAN_INPUT" ;;
+        esac
+
+        echo "Using lava-test-plans project: ${PROJECT}"
+        echo "Resolved: MACHINE=${{ inputs.machine_name }}, DISTRO_NAME=${DISTRO_NAME}, TESTPLAN_DIR=${TESTPLAN_DIR}"
+
+        TESTPLAN_DIR_ABS="lava-test-plans/lava_test_plans/testplans/${PROJECT}/${DISTRO_NAME}/${TESTPLAN_DIR}"
+        if [ ! -d "${TESTPLAN_DIR_ABS}" ]; then
+          echo "ERROR: Test plan directory not found: ${TESTPLAN_DIR_ABS}"
+          ls -al "lava-test-plans/lava_test_plans/testplans/${PROJECT}/${DISTRO_NAME}" || true
+          exit 1
+        fi
+
+        # Create variables file
+        {
+          echo "PROJECT_NAME=${PROJECT}"
+          echo "PROJECT=projects/${PROJECT}/"
+          echo "LAVA_JOB_PRIORITY=50"
+          echo "OS_INFO=qcom-distro"
+          echo "BUILD_NUMBER=${{ inputs.run_id }}-${{ inputs.run_attempt }}"
+          echo "DOCKER_IMAGE_POSTPROCESS=ghcr.io/foundriesio/lava-lmp-sign:main"
+          echo "AUTH_HEADER_NAME=Authentication"
+          echo "AUTH_HEADER_TOKEN=Q_GITHUB_TOKEN"
+          echo "TEST_DEFINITIONS_REPOSITORY=https://github.com/qualcomm-linux/qcom-linux-testkit/"
+          echo "FLASHER_DEVICE_TYPE=qcs"
+        } >> "${VARS_OUT_PATH}/gh-variables.ini"
+
+        IMAGE_TYPE="core-image-base"
+        if [ "${DISTRO_NAME}" = "qcom-distro" ]; then
+          IMAGE_TYPE="qcom-multimedia-image"
+          echo "AUTO_LOGIN_PASSWORD_PROMPT=Password" >> "${VARS_OUT_PATH}/gh-variables.ini"
+          echo "AUTO_LOGIN_PASSWORD=oelinux123"     >> "${VARS_OUT_PATH}/gh-variables.ini"
+        fi
+        echo "IMAGE_FILE_NAME=${IMAGE_TYPE}-${{ inputs.image_name }}.rootfs.qcomflash.tar.gz" >> "${VARS_OUT_PATH}/gh-variables.ini"
+
+        # Use the presigned URL as-is
+        BUILD_URL="${{ inputs.build_url }}"
+        if [ -z "${BUILD_URL}" ]; then
+          echo "BUILD_URL missing"
+          exit 1
+        fi
+        echo "BUILD_DOWNLOAD_URL=${BUILD_URL}" >> "${VARS_OUT_PATH}/gh-variables.ini"
+        echo "ROOTFS_URL=${BUILD_URL}" >> "${VARS_OUT_PATH}/gh-variables.ini"
+        echo "DEVICE_TYPE=${{ inputs.image_name }}" >> "${VARS_OUT_PATH}/gh-variables.ini"
+
+        echo "==== gh-variables.ini ===="
+        cat "${VARS_OUT_PATH}/gh-variables.ini"
+
+        # Generate jobs
+        lava-test-plans \
+          --dry-run \
+          --variables "${VARS_OUT_PATH}/gh-variables.ini" \
+          --test-plan "${PROJECT}/${DISTRO_NAME}/${TESTPLAN_DIR}" \
+          --device-type "projects/${PROJECT}/devices/${{ inputs.machine_name }}" \
+          --dry-run-path "${JOBS_OUT_PATH}/${{ inputs.image_name }}-${DISTRO_NAME}-${TESTPLAN_DIR}" || true
+
+        # Expose the subdir where jobs were generated
+        JOBS_SUBDIR="${JOBS_OUT_PATH}/${{ inputs.image_name }}-${DISTRO_NAME}-${TESTPLAN_DIR}"
+
+        # Find the first YAML job
+        FIRST_JOB=$(find "${JOBS_SUBDIR}" -type f -name '*.yaml' | sort | head -n 1 || true)
+        echo "first_job=${FIRST_JOB:-}" >> $GITHUB_OUTPUT
+        if [ -z "${FIRST_JOB:-}" ]; then
+          echo "WARNING: No YAMLs generated by lava-test-plans in ${JOBS_SUBDIR}"
+        else
+          echo "First generated job: ${FIRST_JOB}"
+        fi
+
+        # Artifact name for upload
+        ARTIFACT_NAME="${{ inputs.prefix }}-${{ inputs.image_name }}-${DISTRO_NAME}"
+        echo "artifact_name=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
+
+    - name: List generated files
+      shell: bash
+      run: |
+        echo "Generated LAVA test jobs:"
+        ls -R "${{ steps.generate-jobs.outputs.jobs_path }}"
+
+    - name: Upload test jobs artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: ${{ steps.generate-jobs.outputs.artifact_name }}
+        path: ${{ steps.generate-jobs.outputs.jobs_path }}/**
+
+    - name: Submit first job to LAVA
+      id: submit-job
+      if: ${{ steps.generate-jobs.outputs.first_job != '' }}
+      uses: foundriesio/lava-action@v9
+      with:
+        lava_token: ${{ inputs.lava_token }}
+        lava_url: ${{ inputs.lava_url }}
+        job_definition: ${{ steps.generate-jobs.outputs.first_job }}
+        wait_for_job: ${{ inputs.wait_for_job }}
+        fail_action_on_failure: ${{ inputs.fail_action_on_failure }}
+        save_result_as_artifact: true
+        save_job_details: true
+        result_file_name: ${{ inputs.image_name }}
+
+    - name: Update summary
+      if: always()
+      shell: bash
+      run: |
+        echo "## LAVA Test Job Summary" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Image:** \`${{ inputs.image_name }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "**Machine:** \`${{ inputs.machine_name }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "**Test Plan:** \`${{ inputs.testplan }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        
+        if [ "${{ steps.submit-job.outcome || 'skipped' }}" == "success" ]; then
+          echo ":heavy_check_mark: LAVA job submitted successfully" >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ steps.submit-job.outcome || 'skipped' }}" == "skipped" ]; then
+          echo ":warning: LAVA job submission was skipped (no jobs generated)" >> $GITHUB_STEP_SUMMARY
+        else
+          echo ":x: LAVA job submission failed" >> $GITHUB_STEP_SUMMARY
+        fi
+        
+        if [ -n "${{ steps.generate-jobs.outputs.first_job }}" ]; then
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Submitted Job:** \`${{ steps.generate-jobs.outputs.first_job }}\`" >> $GITHUB_STEP_SUMMARY
+        fi

--- a/.github/actions/test-job-summary/action.yml
+++ b/.github/actions/test-job-summary/action.yml
@@ -1,0 +1,271 @@
+name: LAVA test job summary
+description: "Download LAVA job artifacts, build a Markdown summary, and upload it as a workflow artifact"
+inputs:
+  build_id:
+    description: "ID of the workflow from which build URL will be downloaded"
+    required: true
+  gh_token:
+    description: "Github token. It's required to download artifacts from the workflow"
+    required: true
+  prefix:
+    description: "Prefix for the compressed file that is uploaded as workflow artifact"
+    default: test-job
+  summary_file_name:
+    description: "File name that is used to save test job summary"
+    default: step-summary.txt
+outputs:
+  artifact_id:
+    description: "ID of the uploaded artifact"
+    value: ${{ steps.upload-summary.outputs.artifact-id }}
+runs:
+  using: "composite"
+
+  steps:
+      
+      - name: Download Artifacts
+        uses: actions/download-artifact@v6
+        with:
+          github-token: ${{ inputs.gh_token }}
+          run-id: ${{ inputs.build_id }}
+          path: artifacts
+          pattern: test-job*
+          merge-multiple: true
+
+
+      - name: "List files"
+        shell: bash
+        run: |
+          echo $GITHUB_WORKSPACE
+          ls -R $GITHUB_WORKSPACE
+
+      - name: Publish Test Job Details
+        shell: bash
+        run: |
+          echo "${{ github.workspace }}"
+          ls -lrt "${{ github.workspace }}"
+          echo "fetching test jobs"
+          python3 << 'EOF'
+          import json
+          import os
+          import sys
+          import requests
+          from collections import defaultdict
+          import urllib3
+          
+          # Disable SSL warnings
+          urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+          
+          def fetch_job_details(job_id):
+              url = f"https://lava.infra.foundries.io/api/v0.2/jobs/{job_id}/"
+              try:
+                  response = requests.get(url, timeout=30, verify=False)
+                  response.raise_for_status()
+                  return response.json()
+              except Exception as e:
+                  print(f"Error fetching job {job_id}: {e}", file=sys.stderr)
+                  return None
+          
+          def fetch_job_suites(job_id):
+              url = f"https://lava.infra.foundries.io/api/v0.2/jobs/{job_id}/suites/"
+              try:
+                  response = requests.get(url, timeout=30, verify=False)
+                  response.raise_for_status()
+                  return response.json()
+              except Exception as e:
+                  print(f"Error fetching suites for job {job_id}: {e}", file=sys.stderr)
+                  return None
+          
+          def fetch_suite_tests(job_id, suite_id):
+              url = f"https://lava.infra.foundries.io/api/v0.2/jobs/{job_id}/suites/{suite_id}/tests/"
+              try:
+                  response = requests.get(url, timeout=30, verify=False)
+                  response.raise_for_status()
+                  return response.json()
+              except Exception as e:
+                  print(f"Error fetching tests for job {job_id}, suite {suite_id}: {e}", file=sys.stderr)
+                  return None
+          
+          def process_test_job(test_job_file):
+              print(f"Processing: {test_job_file}")
+              
+              with open(test_job_file, 'r') as f:
+                  job_data = json.load(f)
+              
+              job_id = job_data.get('id')
+              if not job_id:
+                  return None
+              
+              print(f"  Job ID: {job_id}")
+              
+              job_details = fetch_job_details(job_id)
+              if not job_details:
+                  return None
+              
+              job_health = job_details.get('health')
+              job_state = job_details.get('state')
+              job_device_type = job_details.get('requested_device_type')
+              job_url = f"https://lava.infra.foundries.io/results/{job_id}"
+              
+              print(f"  State: {job_state}, Health: {job_health}, Device: {job_device_type}")
+              
+              test_results = {}
+              
+              if job_state == "Finished" and job_health == "Complete":
+                  suites_data = fetch_job_suites(job_id)
+                  if not suites_data:
+                      return None
+                  
+                  suites = suites_data.get('results', [])
+                  
+                  for suite in suites:
+                      suite_name = suite.get('name')
+                      suite_id = suite.get('id')
+                      
+                      suite_tests = fetch_suite_tests(job_id, suite_id)
+                      if not suite_tests:
+                          continue
+                      
+                      tests = suite_tests.get('results', [])
+                      
+                      if suite_name != "lava":
+                          for test in tests:
+                              test_name = test.get('name')
+                              test_result = test.get('result')
+                              if test_name:
+                                  test_results[test_name] = {
+                                      'result': test_result,
+                                      'url': job_url
+                                  }
+                      else:
+                          test_results['boot'] = {
+                              'result': 'pass',
+                              'url': job_url
+                          }
+              
+              return {
+                  'device_type': job_device_type,
+                  'test_results': test_results,
+                  'job_id': job_id
+              }
+          
+          def generate_summary_table(job_results, summary_file):
+              if not job_results:
+                  print("No results to display")
+                  return
+              
+              all_test_names = set()
+              for job_file, job_info in job_results:
+                  all_test_names.update(job_info['test_results'].keys())
+              
+              test_names = sorted(all_test_names)
+              
+              lines = []
+              lines.append("# LAVA Test Job Results Summary")
+              lines.append("")
+              lines.append(f"**Total Jobs Processed:** {len(job_results)}")
+              lines.append("")
+              
+              # Header
+              header = "| Test |"
+              for job_file, job_info in job_results:
+                  device_type = job_info['device_type']
+                  header += f" {device_type} |"
+              lines.append(header)
+              
+              # Separator
+              separator = "| ---- |"
+              for _ in job_results:
+                  separator += " ---- |"
+              lines.append(separator)
+              
+              # Data rows
+              for test_name in test_names:
+                  row = f"| {test_name} |"
+                  
+                  for job_file, job_info in job_results:
+                      test_results = job_info['test_results']
+                      job_url = f"https://lava.infra.foundries.io/results/{job_info['job_id']}"
+                      
+                      if test_name in test_results:
+                          result = test_results[test_name].get('result', '')
+                          
+                          if result == 'pass':
+                              checkmark = ":white_check_mark:"
+                          elif result == 'fail':
+                              checkmark = ":x:"
+                          elif result == 'skip':
+                              checkmark = ":warning:"
+                          else:
+                              checkmark = ":no_entry_sign:"
+                          
+                          row += f" [{checkmark}]({job_url}) |"
+                      else:
+                          row += f" [:no_entry_sign:]({job_url}) |"
+                  
+                  lines.append(row)
+              
+              # Print to console
+              for line in lines:
+                  print(line)
+              
+              # Write to file
+              with open(summary_file, 'w') as f:
+                  for line in lines:
+                      f.write(line + '\n')
+              
+              print(f"\nSummary written to: {summary_file}")
+          
+          # Main execution
+          workspace = "${{ github.workspace }}"
+          prefix = "${{ inputs.prefix }}"
+          summary_file = "${{ inputs.summary_file_name }}"
+          
+          print(f"Workspace: {workspace}")
+          print(f"Looking for files matching: {prefix}*.json")
+          print("="*80)
+          
+          # Find test job files
+          test_job_files = []
+          for root, dirs, files in os.walk(workspace):
+              for file in files:
+                  if file.startswith(prefix) and file.endswith('.json'):
+                      test_job_files.append(os.path.join(root, file))
+          
+          if not test_job_files:
+              print(f"No test job files found")
+              sys.exit(1)
+          
+          print(f"Found {len(test_job_files)} test job file(s)\n")
+          
+          # Process jobs
+          job_results = []
+          for test_job_file in test_job_files:
+              result = process_test_job(test_job_file)
+              if result:
+                  job_results.append((test_job_file, result))
+              print()
+          
+          # Generate summary
+          generate_summary_table(job_results, summary_file)
+          EOF
+          
+          echo "### All jobs summary" >> ${{inputs.summary_file_name}}
+          echo "" >> ${{inputs.summary_file_name}}
+          echo "| Job ID | Device | State | Health |" >> ${{inputs.summary_file_name}}
+          echo "| ---- | ---- | ---- | ---- |" >> ${{inputs.summary_file_name}}
+          for TESTJOB in $(find ${{ github.workspace }} -name "${{ inputs.prefix }}*.json")
+          do
+              JOB_ID=$(cat "${TESTJOB}" | jq ".id")
+              JOB_URL="https://lava.infra.foundries.io/results/$JOB_ID"
+              JOB_DETAILS=$(curl -s "https://lava.infra.foundries.io/api/v0.2/jobs/$JOB_ID/")
+              JOB_HEALTH=$(echo "$JOB_DETAILS" | jq -r ".health")
+              JOB_STATE=$(echo "$JOB_DETAILS" | jq -r ".state")
+              JOB_DEVICE_TYPE=$(echo "$JOB_DETAILS" | jq -r ".requested_device_type")
+              echo "| [$JOB_ID]($JOB_URL) | $JOB_DEVICE_TYPE | $JOB_STATE | $JOB_HEALTH |" >> ${{inputs.summary_file_name}}
+          done
+      - name: Upload summary
+        id: upload-summary
+        uses: actions/upload-artifact@v6
+        with:
+          path: ${{inputs.summary_file_name}}
+          name: ${{inputs.summary_file_name}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: _test
+name: LAVA Test Workflow
 description: Trigger LAVA tests on the build
 
 on:
@@ -9,7 +9,7 @@ on:
         required: true
         type: string
 
-      # === Optional knobs for lava-test-plans (can also be provided per-matrix item) ===
+      # === Optional knobs for lava-test-plans ===
       distro_name:
         description: Default distro for lava-test-plans if not provided in matrix
         required: false
@@ -30,12 +30,29 @@ on:
         required: false
         type: string
         default: testjobs
+      
+      # === LAVA server configuration ===
+      lava_url:
+        description: LAVA server URL
+        required: false
+        type: string
+        default: lava.infra.foundries.io
+      wait_for_job:
+        description: Wait for LAVA job to complete
+        required: false
+        type: boolean
+        default: true
+      fail_on_test_failure:
+        description: Fail workflow if LAVA test fails
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   submit_lava:
     runs-on:
       group: GHA-AudioReach-SelfHosted-RG
-      labels: [ self-hosted, self-hosted, audior-prd-u2204-x64-large-od-ephem ]
+      labels: [ self-hosted, audior-prd-u2204-x64-large-od-ephem ]
     strategy:
       fail-fast: false
       matrix:
@@ -66,233 +83,75 @@ jobs:
             console.log(url)
             core.setOutput('build_url', url)
 
-      - name: Print trigger
+      - name: Print trigger info
         run: |
           echo "Triggered by ${{ github.event_name }}"
-          echo "Build URL: --->"
-          echo "${{ steps.get_build_url.outputs.build_url }}"
+          echo "Build URL: ${{ steps.get_build_url.outputs.build_url }}"
+          echo "Image: ${{ matrix.build_matrix.image_name }}"
+          echo "Machine: ${{ matrix.build_matrix.machine_name }}"
 
-      - name: "List jobs"
-        id: listjobs
-        shell: bash
-        run: |
-          set -euo pipefail
-          target_file="${{ matrix.build_matrix.test_file }}"
-          if [ ! -f "$target_file" ]; then
-            echo "Target file $target_file does not exist."
-            echo "target=" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
-
-          TARGET=${target_file}
-          FIND_PATH="${TARGET#*/}"
-          # DEVICE_TYPE_PATH="${FIND_PATH%/*}"
-          DEVICE_TYPE="${{ matrix.build_matrix.machine_name }}"
-          NEW_MACHINE="$DEVICE_TYPE"
-
-
-          BUILD_FILE_NAME="qcom-multimedia-image-${{ matrix.build_matrix.image_name }}.rootfs.qcomflash.tar.gz"
-          BUILD_DOWNLOAD_URL="${{ steps.get_build_url.outputs.build_url }}"
-          sed -i "s|{{DEVICE_TYPE}}|${DEVICE_TYPE}|g" "${target_file}"
-          sed -i "s|{{GITHUB_SHA}}|${GITHUB_SHA}|g" "${target_file}"
-
-          # IMPORTANT: use raw sed class (no HTML-escaped &amp;) and replace the placeholder
-          ESCAPED_URL=$(printf '%s\n' "$BUILD_DOWNLOAD_URL" | sed 's/[&/?=]/\\&/g')
-          sed -i "s|{{BUILD_DOWNLOAD_URL}}|${ESCAPED_URL}|g" "${target_file}"
-          sed -i "s|{{BUILD_FILE_NAME}}|${BUILD_FILE_NAME}|g" "${target_file}"
-          sed -i "s|{{GITHUB_RUN_ID}}|${GITHUB_RUN_ID}|g" "${target_file}"
-
-          # ===== PASSWORD-ONLY CHANGE START =====
-          NEW_PW="oelinux123"
-
-          # Replace existing 'password:' inside the auto_login block
-          awk -v pw="$NEW_PW" '
-            BEGIN { in_auto = 0 }
-            /^ *auto_login:/ { in_auto = 1 }
-            in_auto == 1 && /^ *password:/ {
-              sub(/password:.*/, "password: " pw)
-              in_auto = 0
-            }
-            { print }
-          ' "$target_file" > "$target_file.tmp" && mv "$target_file.tmp" "$target_file"
-
-          # If no 'password:' line exists, insert it after 'username: root'
-          if ! grep -qE '^[[:space:]]*password:' "$target_file"; then
-            awk -v pw="$NEW_PW" '
-              BEGIN { in_auto = 0 }
-              {
-                print $0
-                if ($0 ~ /^ *auto_login:/) in_auto = 1
-                else if (in_auto == 1 && $0 ~ /^ *username:[[:space:]]*root/) {
-                  indent = gensub(/^([[:space:]]*).*/, "\\1", 1, $0)
-                  print indent "password_prompt: '\''Password:'\''"
-                  print indent "password: " pw
-                  in_auto = 0
-                }
-              }
-            ' "$target_file" > "$target_file.tmp" && mv "$target_file.tmp" "$target_file"
-          fi
-          # ===== PASSWORD-ONLY CHANGE END =====
-
-          echo "---- Final templated job ----"
-          cat "${target_file}"
-
-          # Outputs for later steps
-          echo "target=${target_file}" >> "$GITHUB_OUTPUT"
-          echo "device_type=${DEVICE_TYPE}" >> "$GITHUB_OUTPUT"
-
-          # Persist to env for later steps
-          echo "DEVICE_TYPE=${DEVICE_TYPE}" >> "$GITHUB_ENV"
-
-      # =========================== lava-test-plans integration START ===========================
-      - name: Checkout lava-test-plans
-        uses: actions/checkout@v5
+      - name: Submit LAVA test job
+        id: lava_submit
+        uses: AudioReach/audioreach-workflows/.github/actions/lava-test-plans@master
         with:
-          repository: qualcomm-linux-stg/lava-test-plans
-          path: lava-test-plans
-          ref: master
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
-      - name: Run lava-test-plans (generate jobs)
-        shell: bash
-        run: |
-          set -euo pipefail
-          cd lava-test-plans && pip install .
-          lava-test-plans --version
-          cd "${GITHUB_WORKSPACE}"
-
-          OUT_PATH="${GITHUB_WORKSPACE}/out"
-          VARS_OUT_PATH="${OUT_PATH}/vars"
-          JOBS_OUT_PATH="${OUT_PATH}/jobs"
-          echo "JOBS_OUT_PATH=${JOBS_OUT_PATH}" >> $GITHUB_ENV
-          mkdir -p "${VARS_OUT_PATH}" "${JOBS_OUT_PATH}"
-
-          # === Plan roots as in the installed package ===
-          PROJECT="meta-qcom"
-          DISTRO_NAME="${{ inputs.distro_name }}"      # qcom-distro
-          MACHINE="${DEVICE_TYPE:-${{ steps.listjobs.outputs.device_type }}}"
-
-          # Map testplan input to a plan directory (pre-merge-basic lives under 'pre-merge')
-          TESTPLAN_INPUT="${{ inputs.testplan }}"
-          case "$TESTPLAN_INPUT" in
-            boot)  TESTPLAN_DIR="boot" ;;
-            pre-merge|pre-merge-basic|pre-merge-bt) TESTPLAN_DIR="pre-merge" ;;
-            *)     TESTPLAN_DIR="$TESTPLAN_INPUT" ;;
-          esac
-
-          echo "Using lava-test-plans project: ${PROJECT}"
-          echo "Resolved: MACHINE=${MACHINE}, DISTRO_NAME=${DISTRO_NAME}, TESTPLAN_DIR=${TESTPLAN_DIR}"
-
-          TESTPLAN_DIR_ABS="lava-test-plans/lava_test_plans/testplans/${PROJECT}/${DISTRO_NAME}/${TESTPLAN_DIR}"
-          if [ ! -d "${TESTPLAN_DIR_ABS}" ]; then
-            echo "ERROR: Test plan directory not found: ${TESTPLAN_DIR_ABS}"
-            ls -al "lava-test-plans/lava_test_plans/testplans/${PROJECT}/${DISTRO_NAME}" || true
-            exit 1
-          fi
-
-          {
-            echo "PROJECT_NAME=${PROJECT}"
-            echo "PROJECT=projects/${PROJECT}/"
-            echo "LAVA_JOB_PRIORITY=50"
-            echo "OS_INFO=qcom-distro"
-            echo "BUILD_NUMBER=${{ github.run_id }}-${{ github.run_attempt }}"
-            echo "DOCKER_IMAGE_POSTPROCESS=ghcr.io/foundriesio/lava-lmp-sign:main"
-            echo "AUTH_HEADER_NAME=Authentication"
-            echo "AUTH_HEADER_TOKEN=Q_GITHUB_TOKEN"
-            echo "TEST_DEFINITIONS_REPOSITORY=https://github.com/qualcomm-linux/qcom-linux-testkit/"
-            echo "FLASHER_DEVICE_TYPE=qcs"
-          } >> "${VARS_OUT_PATH}/gh-variables.ini"
-
-          IMAGE_TYPE="core-image-base"
-          if [ "${DISTRO_NAME}" = "qcom-distro" ]; then
-            IMAGE_TYPE="qcom-multimedia-image"
-            echo "AUTO_LOGIN_PASSWORD_PROMPT=Password" >> "${VARS_OUT_PATH}/gh-variables.ini"
-            echo "AUTO_LOGIN_PASSWORD=oelinux123"     >> "${VARS_OUT_PATH}/gh-variables.ini"
-          fi
-          echo "IMAGE_FILE_NAME=${IMAGE_TYPE}-${{ matrix.build_matrix.image_name }}.rootfs.qcomflash.tar.gz" >> "${VARS_OUT_PATH}/gh-variables.ini"
-
-          # Use the presigned URL as-is (no trailing slash) to avoid breaking query params.
-          BUILD_URL="${{ steps.get_build_url.outputs.build_url }}"
-          if [ -z "${BUILD_URL}" ]; then
-            echo "BUILD_URL missing"
-            exit 1
-          fi
-          echo "BUILD_DOWNLOAD_URL=${BUILD_URL}" >> "${VARS_OUT_PATH}/gh-variables.ini"
-          echo "ROOTFS_URL=${BUILD_URL}" >> "${VARS_OUT_PATH}/gh-variables.ini"
-          echo "DEVICE_TYPE=${{ matrix.build_matrix.image_name }}" >> "${VARS_OUT_PATH}/gh-variables.ini"
-
-          echo "==== gh-variables.ini ===="
-          cat "${VARS_OUT_PATH}/gh-variables.ini"
-
-          lava-test-plans \
-            --dry-run \
-            --variables "${VARS_OUT_PATH}/gh-variables.ini" \
-            --test-plan "${PROJECT}/${DISTRO_NAME}/${TESTPLAN_DIR}" \
-            --device-type "projects/${PROJECT}/devices/${{ matrix.build_matrix.machine_name }}" \
-            --dry-run-path "${JOBS_OUT_PATH}/${{ matrix.build_matrix.image_name }}-${DISTRO_NAME}-${TESTPLAN_DIR}" || true
-
-          # Expose the subdir where jobs were generated (local + export)
-          JOBS_SUBDIR="${JOBS_OUT_PATH}/${{ matrix.build_matrix.image_name }}-${DISTRO_NAME}-${TESTPLAN_DIR}"
-          echo "JOBS_SUBDIR=${JOBS_SUBDIR}" >> $GITHUB_ENV
-
-          # Optionally verify and surface the first YAML (used for single submission)
-          FIRST_JOB=$(find "${JOBS_SUBDIR}" -type f -name '*.yaml' | sort | head -n 1 || true)
-          echo "FIRST_JOB=${FIRST_JOB:-}" >> $GITHUB_ENV
-          if [ -z "${FIRST_JOB:-}" ]; then
-            echo "WARNING: No YAMLs generated by lava-test-plans in ${JOBS_SUBDIR}"
-          else
-            echo "First generated job: ${FIRST_JOB}"
-          fi
-
-          # Artifact name for upload
-          echo "ARTIFACT_NAME=${{ inputs.prefix }}-${{ matrix.build_matrix.image_name }}-${DISTRO_NAME}" >> $GITHUB_ENV
-
-      - name: "List files (lava-test-plans output)"
-        shell: bash
-        run: |
-          echo "${GITHUB_WORKSPACE}"
-          ls -R "${GITHUB_WORKSPACE}"
-          echo "list files completed"
-
-      - name: 'Upload test jobs (lava-test-plans artifact)'
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: ${{ env.JOBS_OUT_PATH }}/**
-
-      # --- Submit only the FIRST generated job ---
-      - name: Submit FIRST generated job via lava-action
-        if: ${{ env.FIRST_JOB != '' }}
-        uses: foundriesio/lava-action@v9
-        with:
+          image_name: ${{ matrix.build_matrix.image_name }}
+          machine_name: ${{ matrix.build_matrix.machine_name }}
+          build_url: ${{ steps.get_build_url.outputs.build_url }}
+          distro_name: ${{ inputs.distro_name }}
+          kernel: ${{ inputs.kernel }}
+          testplan: ${{ inputs.testplan }}
+          prefix: ${{ inputs.prefix }}
           lava_token: ${{ secrets.LAVATOKEN }}
-          lava_url: 'lava.infra.foundries.io'
-          job_definition: ${{ env.FIRST_JOB }}
-          wait_for_job: true
-          fail_action_on_failure: false
-          save_result_as_artifact: true
-          save_job_details: true
+          lava_url: ${{ inputs.lava_url }}
+          wait_for_job: ${{ inputs.wait_for_job }}
+          fail_action_on_failure: ${{ inputs.fail_on_test_failure }}
+          run_id: ${{ github.run_id }}
+          run_attempt: ${{ github.run_attempt }}
 
-      - name: Update Summary
-        if: success() || failure()
-        shell: bash
+  publish-test-summary:
+    name: "Publish Tests Summary"
+    needs: [submit_lava]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+    outputs:
+      summary_id: ${{ steps.generate-summary.outputs.artifact_id }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate Summary
+        id: generate-summary
+        uses: AudioReach/audioreach-workflows/.github/actions/test-job-summary@master
+        with:
+          build_id: ${{ github.run_id }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          summary_file_name: test_job_summary
+      
+      # Download ALL matching summary artifacts from parallel jobs and put into one folder.
+      - name: Download Summaries
+        uses: actions/download-artifact@v6
+        with:
+          pattern: test_job_summary*          # match all parallel summaries
+          merge-multiple: true                # place all matched artifact contents into a single folder
+          path: summaries
+
+      - name: Publish Test Job Details
         run: |
-          echo "${GITHUB_WORKSPACE}"
-          ls -R "${GITHUB_WORKSPACE}"
-          echo "list files called "
-          # tree "${{ env.JOBS_OUT_PATH }}"
-          echo "## Test Job Summary" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.submit_job.outcome || 'failure' }}" == "success" ]; then
-            echo ":heavy_check_mark: Template-based job completed successfully." >> $GITHUB_STEP_SUMMARY
-          else
-            echo ":warning: Template-based job may have failed or was skipped." >> $GITHUB_STEP_SUMMARY
+          shopt -s nullglob
+          files=(summaries/test_job_summary*)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo ":warning: No test job summaries were found to publish." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
-          if [ -n "${FIRST_JOB:-}" ]; then
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### lava-test-plans" >> $GITHUB_STEP_SUMMARY
-            echo "Submitted job: \`${FIRST_JOB}\`" >> $GITHUB_STEP_SUMMARY
-          fi
+
+          echo "## LAVA Test Job Summaries" >> "$GITHUB_STEP_SUMMARY"
+          for f in "${files[@]}"; do
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "### $(basename "$f")" >> "$GITHUB_STEP_SUMMARY"
+            cat "$f" >> "$GITHUB_STEP_SUMMARY"
+          done


### PR DESCRIPTION
Replace job-by-job artifact handling with a unified summary generation flow that gathers all per-matrix results and publishes them in a single GitHub summary.