### PR TITLE
Add raspberrypi4 target and enable target-specific build scripts

### DIFF
--- a/.github/actions/loading/action.yml
+++ b/.github/actions/loading/action.yml
@@ -76,6 +76,7 @@ runs:
                 sdk_name: cfg.SDK_name,
                 image_name: cfg.Image_name,
                 machine_name: cfg.Machine_name,
+                build_script: cfg.Build_script,
                 testing_enabled: cfg.Testing_enabled
               }));
               // Output a FLAT ARRAY to match strategy.matrix.build_matrix: fromJson(...)

--- a/.github/actions/loading/target_image.json
+++ b/.github/actions/loading/target_image.json
@@ -1,9 +1,10 @@
 {
   "rb3gen2-core-kit-6.18": {
     "Test_file": "ci/lava/rb3gen2-core-kit-6.18/boot.yaml",
-    "SDK_name" : "sdk-rb3gen2-core-kit-6.18.sh",
+    "SDK_name": "sdk-rb3gen2-core-kit-6.18.sh",
     "Image_name": "rb3gen2-core-kit-6.18",
     "Machine_name": "rb3gen2-core-kit",
+    "Build_script": "ci/build.sh",
     "Testing_enabled": true
   },
   "rb3gen2-core-kit": {
@@ -11,6 +12,15 @@
     "SDK_name": "sdk-rb3gen2-core-kit.sh",
     "Image_name": "rb3gen2-core-kit",
     "Machine_name": "rb3gen2-core-kit",
+    "Build_script": "ci/build.sh",
     "Testing_enabled": true
+  },
+  "raspberrypi4": {
+    "Test_file": "ci/raspberrypi4.yml",
+    "SDK_name": "sdk-raspberrypi4.sh",
+    "Image_name": "raspberrypi4",
+    "Machine_name": "raspberrypi4",
+    "Build_script": "ci/rpi_build.sh",
+    "Testing_enabled": false
   }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
           docker_image: ${{ steps.get-docker-image.outputs.image_name }}
         env:
           BUILD_ARGS: ${{ inputs.build_args }}
-          BUILD_SCRIPT: ${{ inputs.build_script }}
+          BUILD_SCRIPT: ${{ matrix.build_matrix.build_script }}
           SYNC_SCRIPT: ${{ inputs.sync_script }}
           APPLY_PATCH_SCRIPT: ${{ inputs.apply_patch_script }}
           CONFIG_SCRIPT: ${{ inputs.config_script }}

--- a/.github/workflows/process_image.yml
+++ b/.github/workflows/process_image.yml
@@ -89,6 +89,7 @@ jobs:
 
       - name: Pull meta-audioreach pre compiled image
         id: pull_meta_audioreach
+        if: ${{ env.IMAGE_NAME != 'raspberrypi4' }}
         uses: AudioReach/audioreach-workflows/.github/actions/aws-s3-exchanger@master
         with:
           s3_bucket: qli-prd-audior-gh-artifacts
@@ -99,6 +100,7 @@ jobs:
 
       - name: Extract image and mount
         id: extract_image
+        if: ${{ env.IMAGE_NAME != 'raspberrypi4' }}
         shell: bash
         run: |
           #!/bin/bash
@@ -145,6 +147,7 @@ jobs:
 
       - name: Create tar image for qcomflash directory
         id: create_tar_image
+        if: ${{ env.IMAGE_NAME != 'raspberrypi4' }}
         shell: bash
         run: |
           #!/bin/bash
@@ -156,6 +159,7 @@ jobs:
 
       - name: Upload tar image
         id: upload_tar_image
+        if: ${{ env.IMAGE_NAME != 'raspberrypi4' }}
         uses: AudioReach/audioreach-workflows/.github/actions/aws-s3-exchanger@master
         with:
           s3_bucket: qli-prd-audior-gh-artifacts


### PR DESCRIPTION
Add raspberrypi4 target and introduce Build_script for all targets. Pass the field through the loading action into the build matrix.

Update build.yml to read build_script from the matrix to ensure each platform uses the correct script.