### PR TITLE
Remove pre-build setup from github workflows

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -7,12 +7,6 @@ inputs:
     required: true
     description: Docker image for build
 
-  build_matrix:            # <-- added
-    required: true
-    type: string
-    description: JSON string for the build matrix
-
-
 runs:
   using: 'composite'
   steps:
@@ -27,9 +21,11 @@ runs:
         # Load the build arguments
         set +x
         export GITHUB_WORKSPACE="${{ github.workspace }}"
+        export SDK_NAME="${{ env.SDK_NAME }}"
         [ -f "./${{ env.CONFIG_SCRIPT }}" ] && export CONFIG_SCRIPT="${{ env.CONFIG_SCRIPT }}"
         [ -f "./${{ env.SYNC_SCRIPT }}" ] && source "./${{ env.SYNC_SCRIPT }}"
         [ -f "./${{ env.APPLY_PATCH_SCRIPT }}" ] && source "./${{ env.APPLY_PATCH_SCRIPT }}"
+        [ -f "./${{ env.PREBUILD_SCRIPT }}" ] && source "./${{ env.PREBUILD_SCRIPT }}"
 
         # Build inside a docker container
         docker run \
@@ -40,6 +36,8 @@ runs:
           -e GITHUB_WORKSPACE="${{ github.workspace }}" \
           -e BUILD_ARGS="${{ env.BUILD_ARGS }}" \
           -e BUILD_SCRIPT="${{ env.BUILD_SCRIPT }}" \
+          -e PREBUILD_SCRIPT="${{ env.PREBUILD_SCRIPT }}" \
+          -e SDK_NAME="${{ env.SDK_NAME }}" \
           --privileged \
           ${{ inputs.docker_image }} \
           bash -c '

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,10 @@ on:
         type: string
         description: Required build arguments
 
-      build_matrix:            # <-- added
+      build_matrix:
         required: true
         type: string
         description: JSON string for the build matrix
-
 
       build_script:
         required: false
@@ -43,6 +42,13 @@ on:
         default: 'ci/config.sh'
         description: Optional script to configure the build environment
         # This script contains the repositories and patches information for the build
+
+      pre_build_script:
+        required: false
+        type: string
+        default: 'ci/pre_build.sh'
+        description: Optional script to run before the build step
+        # This script is used to perform any setup or configuration before the build step
 
       event_name:
         required: false
@@ -98,26 +104,6 @@ jobs:
           pr_repo: ${{ inputs.pr_repo }}
           base_ref: ${{ inputs.base_ref }}
 
-      - name: Pull SDK sh file
-        id: pull_sdk
-        uses: AudioReach/audioreach-workflows/.github/actions/aws-s3-exchanger@master
-        with:
-          s3_bucket: qli-prd-audior-gh-artifacts
-          download_filename: ${{ env.SDK_NAME }}
-          mode: download
-          location: AudioReach/meta-audioreach/post_merge_build
-
-      - name: Setup Directory Structure
-        run: mkdir -p install/tmp
-
-      - name: Run SDK Script
-        id: run_sdk
-        shell: bash
-        run: |
-          echo "Running SDK Script"
-          echo "./install" | ./${{ env.SDK_NAME }}
-          echo "SDK Script ran successfully"
-
       - name: Build
         id: build
         uses: AudioReach/audioreach-workflows/.github/actions/build@master
@@ -129,6 +115,7 @@ jobs:
           SYNC_SCRIPT: ${{ inputs.sync_script }}
           APPLY_PATCH_SCRIPT: ${{ inputs.apply_patch_script }}
           CONFIG_SCRIPT: ${{ inputs.config_script }}
+          PREBUILD_SCRIPT: ${{ inputs.pre_build_script }}
 
       - name: Clean Up Workspace
         if: always() 

--- a/.github/workflows/process_image.yml
+++ b/.github/workflows/process_image.yml
@@ -35,7 +35,6 @@ on:
         description: Optional base reference to use for building
         default: ${{ github.ref_name }}
 
-
       build_matrix:                 # <-- added (required for matrix below)
         required: true
         type: string
@@ -132,7 +131,6 @@ jobs:
               sudo mount rootfs.img /tmp/rootfs
               echo "Image mounted successfully"
               
-
               # Copy the arg build files to the mounted image
               sudo bash -c "source /workspace/${FILES_TO_COPY}"
               echo "Build files copied successfully"


### PR DESCRIPTION
This commit removes the pre-build setup steps from the workflow. This requirement came as a part of enabling ABI compatibality checks on Audioreach repositories.

We are doing this because:
- The existing build.sh script is not fully self‑contained. pre‑build setup steps are maintained inside the CI workflow instead of being part of the script. So, Script is not usable standalone.
- This prevents the ABI checker (or any future build‑dependent workflow) from simply invoking build.sh to perform a minimal build.