### PR TITLE
Enable RPI build on audioreach-engine

### DIFF
--- a/.github/actions/loading/target_image.json
+++ b/.github/actions/loading/target_image.json
@@ -27,7 +27,7 @@
     "Build_script": "ci/rpi_build.sh",
     "Build_args": "ci/rpi_build_options.txt",
     "Testing_enabled": false,
-    "Disabled_repos": ["audioreach-pal", "audioreach-conf", "audioreach-audio-utils", "audioreach-engine"]
+    "Disabled_repos": ["audioreach-pal", "audioreach-conf", "audioreach-audio-utils"]
   },
   "sm8750-mtp": {
     "Test_file": "ci/sm8750-mtp.yml",


### PR DESCRIPTION
Remove audioreach-engine from the Disabled_repos list for the RPI target image configuration.