### PR TITLE
Update workflows to support pull_request event and artifact layout

### DIFF
--- a/.github/actions/aws-s3-exchanger/action.yml
+++ b/.github/actions/aws-s3-exchanger/action.yml
@@ -54,7 +54,7 @@ runs:
             echo "presigned_url=${presigned_url}" >> "$GITHUB_OUTPUT"
 
             # Also write the URL into a uniquely named file for artifact download
-            echo "${presigned_url}" > "${{ github.workspace }}/presigned_url_${{ env.IMAGE_NAME }}.txt"
+            echo "${presigned_url}" > "${{ github.workspace }}/presigned_urls/presigned_url_${{ env.IMAGE_NAME }}.txt"
             ;;
           download)
             #Download The required file from s3
@@ -77,5 +77,5 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: presigned_url_${{ env.IMAGE_NAME }}.txt
-        path: ${{ github.workspace }}/presigned_url_${{ env.IMAGE_NAME }}.txt
+        path: ${{ github.workspace }}/presigned_urls/presigned_url_${{ env.IMAGE_NAME }}.txt
         retention-days: 1

--- a/.github/actions/sync/action.yml
+++ b/.github/actions/sync/action.yml
@@ -20,7 +20,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout Code (pull_request_target)
-      if: ${{ (inputs.event_name == 'pull_request_target' || inputs.event_name == 'workflow_call') && inputs.pr_ref != '' && inputs.pr_repo != '' }}
+      if: ${{ (inputs.event_name == 'pull_request' || inputs.event_name == 'workflow_call') && inputs.pr_ref != '' && inputs.pr_repo != '' }}
       uses: actions/checkout@v4   # actions/checkout@v4
       with:
         fetch-depth: 0  # Fetch all history for all branches and tags

--- a/.github/workflows/process_image.yml
+++ b/.github/workflows/process_image.yml
@@ -46,6 +46,7 @@ jobs:
     runs-on:
       group: GHA-AudioReach-SelfHosted-RG
       labels: [ self-hosted, self-hosted, audior-prd-u2204-x64-large-od-ephem ]
+
     strategy:
       fail-fast: false
       matrix:
@@ -155,7 +156,24 @@ jobs:
           echo $PWD
           echo "Creating tar image for qcomflash directory"
           tar -czvf qcom-multimedia-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz ${{ env.ROOTFS_DIR }}/
-          echo "Tar image created successfully"
+
+      # ✅ Moving newly created tar files into presigned_urls path
+      - name: Move tar to presigned_urls directory
+        if: ${{ env.IMAGE_NAME != 'raspberrypi4' }}
+        shell: bash
+        run: |
+          set -e
+          mkdir -p ${{ github.workspace }}/presigned_urls
+
+          FILE="qcom-multimedia-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz"
+
+          if [ ! -f "$FILE" ]; then
+            echo "ERROR: $FILE not found!"
+            exit 1
+          fi
+
+          mv "$FILE" ${{ github.workspace }}/presigned_urls/
+          echo "Moved $FILE to presigned_urls/"
 
       - name: Upload tar image
         id: upload_tar_image
@@ -163,5 +181,6 @@ jobs:
         uses: AudioReach/audioreach-workflows/.github/actions/aws-s3-exchanger@master
         with:
           s3_bucket: qli-prd-audior-gh-artifacts
-          local_file: ${{ github.workspace }}/qcom-multimedia-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz
+          local_file: ${{ github.workspace }}/presigned_urls/qcom-multimedia-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz
           mode: upload
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,11 @@ on:
         required: true
         type: string
 
-      # === Optional knobs for lava-test-plans ===
+      build_urls:
+        description: JSON map of image_name → build URL
+        required: true
+        type: string
+
       distro_name:
         description: Default distro for lava-test-plans if not provided in matrix
         required: false
@@ -31,7 +35,6 @@ on:
         type: string
         default: testjobs
       
-      # === LAVA server configuration ===
       lava_url:
         description: LAVA server URL
         required: false
@@ -59,9 +62,6 @@ jobs:
         build_matrix: ${{ fromJSON(inputs.build_matrix) }}
 
     steps:
-
-      # If your matrix sometimes uses a string "true", replace the if: with:
-      # if: ${{ !fromJSON('["true", true]').includes(matrix.build_matrix.testing_enabled) }}
       - name: Skip if testing disabled
         if: ${{ matrix.build_matrix.testing_enabled != true }}
         env:
@@ -78,23 +78,23 @@ jobs:
           fetch-depth: 0
           repository: AudioReach/meta-audioreach
 
-      - name: Download presigned URL
-        id: download_url
-        uses: actions/download-artifact@v7
-        with:
-          name: presigned_url_${{ matrix.build_matrix.image_name }}.txt
-          path: ${{ github.workspace }}
-
       - name: Get build URL
         id: get_build_url
         uses: actions/github-script@v8
         with:
           script: |
-            const fs = require('fs')
-            const filePath = `${{ github.workspace }}/presigned_url_${{ matrix.build_matrix.image_name }}.txt`
-            const url = fs.readFileSync(filePath, 'utf8').toString().trim()
-            console.log(url)
-            core.setOutput('build_url', url)
+            const urls = JSON.parse('${{ inputs.build_urls }}')
+            const image = '${{ matrix.build_matrix.image_name }}'
+
+            const key = `presigned_url_${image}.txt`
+            const matched = urls[key]
+
+            if (!matched) {
+              throw new Error(`No exact build URL found for image: ${image}`)
+            }
+
+            console.log(`Using URL for ${image}: ${matched}`)
+            core.setOutput('build_url', matched)
 
       - name: Print trigger info
         env:
@@ -150,12 +150,11 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           summary_file_name: test_job_summary
       
-      # Download ALL matching summary artifacts from parallel jobs and put into one folder.
       - name: Download Summaries
         uses: actions/download-artifact@v6
         with:
-          pattern: test_job_summary*          # match all parallel summaries
-          merge-multiple: true                # place all matched artifact contents into a single folder
+          pattern: test_job_summary*
+          merge-multiple: true
           path: summaries
 
       - name: Publish Test Job Details


### PR DESCRIPTION
Update sync action to use pull_request instead of pull_request_target to align with updated workflow trigger behavior.

Update test workflow to consume presigned URLs from bundled artifact instead of per-matrix files. Adjust download path and read logic to handle nested artifact directories.

Add path handling using path.join and improve logging for debugging artifact structure and file resolution.