### PR TITLE
Use proprietary multimedia image name across workflows

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -174,7 +174,7 @@ runs:
 
         IMAGE_TYPE="core-image-base"
         if [ "${DISTRO_NAME}" = "qcom-distro" ]; then
-          IMAGE_TYPE="qcom-multimedia-image"
+          IMAGE_TYPE="qcom-multimedia-proprietary-image"
           printf 'AUTO_LOGIN_PASSWORD_PROMPT=%s\n' "Password" >> "${VARS_FILE}"
           printf 'AUTO_LOGIN_PASSWORD=%s\n' "oelinux123"   >> "${VARS_FILE}"
         fi

--- a/.github/workflows/process_image.yml
+++ b/.github/workflows/process_image.yml
@@ -95,8 +95,8 @@ jobs:
         with:
           s3_bucket: qli-prd-audior-gh-artifacts
           mode: download
-          #qcom-multimedia-image-rb3gen2-core-kit.rootfs.qcomflash.tar.gz
-          download_filename: qcom-multimedia-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz
+          #qcom-multimedia-proprietary-image-rb3gen2-core-kit.rootfs.qcomflash.tar.gz
+          download_filename: qcom-multimedia-proprietary-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz
           location: AudioReach/meta-audioreach/post_merge_build
 
       - name: Extract image and mount
@@ -108,13 +108,13 @@ jobs:
           set -e
 
           echo "Extracting the image"
-          tar -xvf qcom-multimedia-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz
-          ROOTFS_IMG=$(tar -tf qcom-multimedia-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz | grep 'rootfs.img$')
+          tar -xvf qcom-multimedia-proprietary-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz
+          ROOTFS_IMG=$(tar -tf qcom-multimedia-proprietary-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz | grep 'rootfs.img$')
           ROOTFS_DIR=$(dirname "$ROOTFS_IMG")
           # Export as GitHub Actions environment variables
           echo "ROOTFS_IMG=$ROOTFS_IMG" >> $GITHUB_ENV
           echo "ROOTFS_DIR=$ROOTFS_DIR" >> $GITHUB_ENV
-          rm -rf qcom-multimedia-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz
+          rm -rf qcom-multimedia-proprietary-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz
           echo "Image extracted successfully"
 
           ls -l "$ROOTFS_DIR/rootfs.img"
@@ -155,7 +155,7 @@ jobs:
           set -e
           echo $PWD
           echo "Creating tar image for qcomflash directory"
-          tar -czvf qcom-multimedia-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz ${{ env.ROOTFS_DIR }}/
+          tar -czvf qcom-multimedia-proprietary-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz ${{ env.ROOTFS_DIR }}/
 
       # ✅ Moving newly created tar files into presigned_urls path
       - name: Move tar to presigned_urls directory
@@ -165,7 +165,8 @@ jobs:
           set -e
           mkdir -p ${{ github.workspace }}/presigned_urls
 
-          FILE="qcom-multimedia-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz"
+          FILE="qcom-multimedia-proprietary-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz"
+
 
           if [ ! -f "$FILE" ]; then
             echo "ERROR: $FILE not found!"
@@ -181,6 +182,6 @@ jobs:
         uses: AudioReach/audioreach-workflows/.github/actions/aws-s3-exchanger@master
         with:
           s3_bucket: qli-prd-audior-gh-artifacts
-          local_file: ${{ github.workspace }}/presigned_urls/qcom-multimedia-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz
+          local_file: ${{ github.workspace }}/presigned_urls/qcom-multimedia-proprietary-image-${{ env.IMAGE_NAME }}.rootfs.qcomflash.tar.gz
           mode: upload
 


### PR DESCRIPTION
Switch image name to qcom-multimedia-proprietary-image across GitHub Actions and related scripts.

Update download, extraction, packaging, and upload steps to use the new image naming convention. This ensures consistency with updated build artifacts and avoids mismatches during image processing and LAVA test plan execution.

Also adjust default IMAGE_TYPE for qcom-distro to align with the proprietary image variant.