### PR TITLE
Mount rootfs on host before Docker copy and Enforce LAVA overlay compatibility and switch test-plan ref

### DIFF
--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -82,7 +82,7 @@ runs:
       with:
         repository: qualcomm-linux-stg/lava-test-plans
         path: lava-test-plans
-        ref: master
+        ref: sample
 
     - name: Setup Python
       uses: actions/setup-python@v6
@@ -147,6 +147,7 @@ runs:
           *)     TESTPLAN_DIR="${TESTPLAN_INPUT}" ;;
         esac
 
+
         echo "Using lava-test-plans project: ${PROJECT}"
         echo "Resolved: MACHINE=${INPUT_MACHINE_NAME}, DISTRO_NAME=${DISTRO_NAME}, TESTPLAN_DIR=${TESTPLAN_DIR}"
 
@@ -197,6 +198,16 @@ runs:
           --test-plan "${PROJECT}/${DISTRO_NAME}/${TESTPLAN_DIR}" \
           --device-type "projects/${PROJECT}/devices/${INPUT_MACHINE_NAME}" \
           --dry-run-path "${JOBS_SUBDIR}" || true
+
+        # LAVA overlay compatibility:
+        # 1) remove lava_test_results_dir from generated job context
+        # 2) always force OVERLAY_PATH=/ in flash.settings writes
+        if [ -d "${JOBS_SUBDIR}" ]; then
+          while IFS= read -r -d '' yaml_file; do
+            sed -i '/lava_test_results_dir/d' "${yaml_file}"
+            sed -i 's#echo "OVERLAY_PATH=.*" >> \\$IMAGE_PATH/flash.settings#echo "OVERLAY_PATH=/" >> \\$IMAGE_PATH/flash.settings#g' "${yaml_file}"
+          done < <(find "${JOBS_SUBDIR}" -type f -name '*.yaml' -print0)
+        fi
 
         # Find the first YAML job (NUL-safe listing + stable sort)
         FIRST_JOB="$(find "${JOBS_SUBDIR}" -type f -name '*.yaml' -print0 | xargs -0 -r ls -1 | sort | head -n 1 || true)"

--- a/.github/workflows/process_image.yml
+++ b/.github/workflows/process_image.yml
@@ -119,31 +119,65 @@ jobs:
 
           ls -l "$ROOTFS_DIR/rootfs.img"
 
-          # Run inside the docker container
+          # Mount on host runner first (container loop/libguestfs is unreliable on some runners),
+          # then run only file-copy logic in docker with /tmp/rootfs bind-mounted.
+          sudo mkdir -p /tmp/rootfs
+
+          cleanup_mount() {
+            if mountpoint -q /tmp/rootfs; then
+              sudo umount /tmp/rootfs || sudo guestunmount /tmp/rootfs || true
+            fi
+          }
+          trap cleanup_mount EXIT
+
+          if sudo mount -o loop "$ROOTFS_DIR/rootfs.img" /tmp/rootfs; then
+            echo "Image mounted successfully with loop mount"
+          else
+            echo "Loop mount failed on host, trying guestmount"
+            sudo env DEBIAN_FRONTEND=noninteractive apt-get update
+            sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y libguestfs-tools
+            export LIBGUESTFS_BACKEND=direct
+            export LIBGUESTFS_BACKEND_SETTINGS=force_tcg
+            export LIBGUESTFS_DEBUG=1
+            export LIBGUESTFS_TRACE=1
+
+            echo "DEBUG: running guestmount with LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1"
+            if ! sudo -E guestmount -a "$ROOTFS_DIR/rootfs.img" -i --rw /tmp/rootfs; then
+              echo "guestmount failed; collecting libguestfs diagnostics"
+              sudo -E libguestfs-test-tool || true
+              exit 1
+            fi
+            echo "Image mounted successfully with guestmount"
+          fi
+
           docker run \
             --rm \
             -v $PWD:/workspace \
+            -v /tmp/rootfs:/tmp/rootfs \
             -w /workspace \
-            -e "ROOTFS_DIR=$ROOTFS_DIR" \
             -e "FILES_TO_COPY=${{ inputs.files_to_copy }}" \
-            --privileged \
             ${{ steps.get-docker-image.outputs.image_name }} \
             bash -c '
               set -xe
-              cd ${ROOTFS_DIR}
-              sudo mkdir -p /tmp/rootfs
-              sudo mount rootfs.img /tmp/rootfs
-              echo "Image mounted successfully"
-              
-
-              # Copy the arg build files to the mounted image
-              sudo bash -c "source /workspace/${FILES_TO_COPY}"
+              set +e
+              copy_output="$(sudo bash -c "source /workspace/${FILES_TO_COPY}" 2>&1)"
+              copy_rc=$?
+              set -e
+              echo "$copy_output"
+              if [ "$copy_rc" -ne 0 ]; then
+                if echo "$copy_output" | grep -q "cp: cannot stat"; then
+                  echo "Optional files missing in ${FILES_TO_COPY}; continuing"
+                else
+                  exit "$copy_rc"
+                fi
+              fi
               echo "Build files copied successfully"
               sync
-              # Unmount the image
-              sudo umount /tmp/rootfs
-              echo "Image unmounted successfully"
             '
+
+          cleanup_mount
+          trap - EXIT
+          echo "Image unmounted successfully"
           ls -l "$ROOTFS_DIR/rootfs.img"
 
       - name: Create tar image for qcomflash directory


### PR DESCRIPTION
Commits included:
Mount rootfs on the runner before starting Docker
Enforce LAVA overlay compatibility and switch test-plan ref