### PR TITLE
Pin GitHub Actions to commit SHAs and harden workflow security

### DIFF
--- a/.github/actions/aws-s3-exchanger/action.yml
+++ b/.github/actions/aws-s3-exchanger/action.yml
@@ -89,7 +89,7 @@ runs:
     - name: Upload Pre-signed URL
       id: upload_presigned_url
       if: ${{ inputs.mode == 'upload' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: presigned_url_${{ env.IMAGE_NAME }}.txt
         path: ${{ github.workspace }}/presigned_urls/presigned_url_${{ env.IMAGE_NAME }}.txt

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -100,7 +100,7 @@ runs:
 
     - name: Upload build.tar
       id: upload_build_tar
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: build_${{ env.IMAGE_NAME }}.tar
         path: ${{ github.workspace }}/build_${{ env.IMAGE_NAME }}.tar

--- a/.github/actions/build_docker_image/action.yml
+++ b/.github/actions/build_docker_image/action.yml
@@ -11,13 +11,14 @@ runs:
   steps:
     # Checkout ar-image repository to get the Dockerfile
     - name: Checkout ar-image repo for Dockerfile
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       with:
         fetch-depth: 0
         repository: AudioReach/ar-image
+        persist-credentials: false
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
     - name: Pre-Build Docker Image
       id: pre-build
@@ -33,7 +34,7 @@ runs:
 
     - name: Build Docker Image
       id: build
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
       with:
         context: .
         push: false

--- a/.github/actions/lava-test-plans/action.yml
+++ b/.github/actions/lava-test-plans/action.yml
@@ -78,14 +78,15 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout lava-test-plans
-      uses: actions/checkout@v5
+      uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       with:
         repository: qualcomm-linux-stg/lava-test-plans
         path: lava-test-plans
         ref: sample
+        persist-credentials: false
 
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
       with:
         python-version: '3.11'
 
@@ -237,7 +238,7 @@ runs:
         fi
 
     - name: Upload test jobs artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
       with:
         name: ${{ steps.generate-jobs.outputs.artifact_name }}
         path: ${{ steps.generate-jobs.outputs.jobs_path }}/**
@@ -245,7 +246,7 @@ runs:
     - name: Submit first job to LAVA
       id: submit-job
       if: ${{ steps.generate-jobs.outputs.first_job != '' }}
-      uses: foundriesio/lava-action@v9
+      uses: foundriesio/lava-action@fe00b480d3b0f276cb4023052c7f6bc67e805953
       with:
         lava_token: ${{ inputs.lava_token }}
         lava_url: ${{ inputs.lava_url }}

--- a/.github/actions/loading/action.yml
+++ b/.github/actions/loading/action.yml
@@ -17,12 +17,15 @@ runs:
   steps:
     - name: Parse Target_image.json to matrix
       id: parse_matrix
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        TARGET_IMAGE_FILE: ${{ inputs.target_image_file }}
       with:
         script: |
           const fs = require('fs');
           const path = require('path');
-          const p = `${{ github.action_path }}/${{ inputs.target_image_file }}`;
+          const p = path.join(process.env.ACTION_PATH, process.env.TARGET_IMAGE_FILE);
 
           if (!fs.existsSync(p)) {
             core.setFailed(`Target image file not found: ${p}`);

--- a/.github/actions/sync/action.yml
+++ b/.github/actions/sync/action.yml
@@ -21,29 +21,33 @@ runs:
   steps:
     - name: Checkout Code (pull_request_target)
       if: ${{ (inputs.event_name == 'pull_request' || inputs.event_name == 'workflow_call') && inputs.pr_ref != '' && inputs.pr_repo != '' }}
-      uses: actions/checkout@v4   # actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262   # actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       with:
         fetch-depth: 0  # Fetch all history for all branches and tags
         ref: ${{ inputs.pr_ref }}
         repository: ${{ inputs.pr_repo }}
+        persist-credentials: false
 
     - name: Checkout master (push)
       if: ${{ (inputs.event_name == 'push' || inputs.event_name == 'workflow_call') && inputs.base_ref != '' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       with:
         fetch-depth: 0
         ref: ${{ inputs.base_ref }}
+        persist-credentials: false
 
     - name: Checkout current repo and ref (Fallback)
       if: ${{ (inputs.event_name == 'push' || inputs.event_name == 'workflow_call') && (inputs.base_ref == '' || inputs.pr_repo == '') }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       with:
         fetch-depth: 0
         ref: ${{ github.ref }}
+        persist-credentials: false
 
     - name: Checkout for workflow_dispatch
       if: ${{ inputs.event_name == 'workflow_dispatch' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       with:
         fetch-depth: 0
         ref: ${{ inputs.base_ref }}
+        persist-credentials: false

--- a/.github/actions/test-job-summary/action.yml
+++ b/.github/actions/test-job-summary/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: Download Artifacts
         # This step is safe because inputs are not interpolated into shell.
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
       with:
         github-token: ${{ inputs.gh_token }}
         run-id: ${{ inputs.build_id }}
@@ -327,7 +327,7 @@ runs:
 
     - name: Upload summary
       id: upload-summary
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
       with:
         path: ${{ inputs.summary_file_name }}
         name: ${{ inputs.summary_file_name }}

--- a/.github/workflows/process_image.yml
+++ b/.github/workflows/process_image.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Download build artifact
         id: download_build_artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           name: build_${{ env.IMAGE_NAME }}.tar
           path: ${{ github.workspace }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,14 +73,15 @@ jobs:
           exit 0
 
       - name: Clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           fetch-depth: 0
           repository: AudioReach/meta-audioreach
+          persist-credentials: false
 
       - name: Get build URL
         id: get_build_url
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         env:
           BUILD_URLS_JSON: ${{ inputs.build_urls }}
           IMAGE_NAME: ${{ matrix.build_matrix.image_name }}
@@ -141,9 +142,10 @@ jobs:
       summary_id: ${{ steps.generate-summary.outputs.artifact_id }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate Summary
         id: generate-summary
@@ -154,7 +156,7 @@ jobs:
           summary_file_name: test_job_summary
       
       - name: Download Summaries
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
         with:
           pattern: test_job_summary*
           merge-multiple: true


### PR DESCRIPTION
Pin GitHub Actions to immutable commit SHAs

Replace version tags with specific commit SHAs across GitHub Actions to prevent unexpected upstream changes and satisfy security recommendations.

Disable credential persistence for checkout steps to reduce token exposure during workflow execution.

Move github.action_path and target image file inputs into environment variables and use path.join() for safer path construction in the loading action.

Update artifact upload and download actions, checkout, github-script, setup-python, Docker Buildx, Docker build, and LAVA actions to vetted commit-pinned revisions.